### PR TITLE
chore: added deploy.yml file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,20 +9,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # necesario para push a gh-pages
+      contents: write  # necessary for pushing to gh-pages
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
 
       - name: Build WASM/JS distribution
         run: ./gradlew :composeApp:wasmJsBrowserDistribution

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # necesario para push a gh-pages
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build WASM/JS distribution
+        run: ./gradlew :composeApp:wasmJsBrowserDistribution
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: composeApp/build/dist/wasmJs/productionExecutable
+          publish_branch: gh-pages


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of a WASM/JS application to GitHub Pages. The workflow is triggered on pushes to the `main` branch and includes steps for setting up the environment, building the application, and deploying it.

### New GitHub Actions Workflow for Deployment:

* `.github/workflows/deploy.yml`: Added a workflow named "Deploy to GitHub Pages" that:
  - Triggers on pushes to the `main` branch.
  - Sets up the environment with JDK 17 and Gradle.
  - Builds the WASM/JS distribution using the Gradle task `:composeApp:wasmJsBrowserDistribution`.
  - Deploys the built files to the `gh-pages` branch using the `peaceiris/actions-gh-pages` action.